### PR TITLE
Remove soda-ash dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ account. If user has multiple accounts, select field will be presented, otherwis
 This component uses [React Semantic UI](https://react.semantic-ui.com). 
 
 ## Installation
-Add `[district0x/district-ui-component-active-account "1.0.0"]` into your project.clj  
+Add [![Clojars Project](https://img.shields.io/clojars/v/district0x/district-ui-component-active-account.svg)](https://clojars.org/district0x/district-ui-component-active-account) into your project.clj  
 Include `[district.ui.component.active-account]` in your CLJS file
 
 ## Module dependencies

--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,6 @@
   thheller/shadow-cljs {:mvn/version "2.19.3"}
   org.clojure/clojurescript {:mvn/version "1.11.60"}
   io.github.district0x/district-ui-web3-accounts {:mvn/version "1.1.0-SNAPSHOT"}
-  soda-ash/soda-ash {:mvn/version "0.83.0"}
   re-frame/re-frame {:mvn/version "1.2.0"}}
 
  :install-deps true

--- a/src/district/ui/component/active_account.cljs
+++ b/src/district/ui/component/active_account.cljs
@@ -3,8 +3,7 @@
     [district.ui.web3-accounts.events :as accounts-events]
     [district.ui.web3-accounts.subs :as accounts-subs]
     [re-frame.core :refer [subscribe dispatch]]
-    [reagent.core :as r]
-    [soda-ash.core :as ui]))
+    [reagent.core :as r]))
 
 (defn active-account []
   (let [accounts (subscribe [::accounts-subs/accounts])
@@ -16,16 +15,15 @@
            [:span.single-account
             single-account-props
             @active-acc]
-           [ui/Select
+           [:select
             (r/merge-props
-             {:select-on-blur false
-              :class "active-account-select"
-              :value @active-acc
-              :on-change (fn [e data]
-                           (dispatch [::accounts-events/set-active-account (aget data "value")]))
-              :fluid true
-              :options (doall (for [acc @accounts]
-                                {:value acc :text acc}))}
-             select-props)])]
+              {:class "active-account-select"
+               :value @active-acc
+               :on-change (fn [item]
+                            (let [val (-> item .-target .-value)]
+                              (dispatch [::accounts-events/set-active-account val])))}
+              select-props)
+            (map (fn [account]
+                   [:option {:key account :value account} account]) @accounts)])]
         [:div
          "Ethereum wallet not connected"]))))


### PR DESCRIPTION
Get rid of soda-ash dependency. It is no longer maintained and presents some troubles for recent react versions